### PR TITLE
#70 is sorted

### DIFF
--- a/public/js/Builder.js
+++ b/public/js/Builder.js
@@ -182,7 +182,8 @@ export default class Builder {
      * 
      * very epic I know :)
      * @param {Element} cardElement 
-     * @param {number} newBoost new boost number to use (if not given, increments the current boost number by 1)
+     * @param {number} newBoost new boost number to use
+     * (if not given, increments the current boost number by 1. If -1 is given, decrements current boost number by 1)
      */
     changeCardBoost(cardElement, newBoost = undefined){
         //const boostLabel = cardElement.querySelector("span").innerText.split("/");
@@ -190,7 +191,10 @@ export default class Builder {
 
         const boost_quantity = cardElement.querySelector(".copycat_boosts_num").innerText;
 
-        if (newBoost === undefined){
+        if (newBoost === -1){
+            newBoost = --cardElement.querySelector(".copycat_current_num").innerText;
+            newBoost = (newBoost <= 0) ? boost_quantity : newBoost;
+        } else if (newBoost === undefined){
             newBoost = ++cardElement.querySelector(".copycat_current_num").innerText;
             newBoost = (newBoost > boost_quantity) ? 1 : newBoost;
         } else if (newBoost <= 0 || newBoost > boost_quantity){

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -326,20 +326,13 @@ window.onload = async () => {
 
     // Perk card clickables (with boosts) //
     for(const e of document.querySelectorAll(".pk_deck_cards .pk_has_boost")) {
-        e.addEventListener("mousedown", ev => {
+        // left-click
+        e.addEventListener("click", ev => {
 
+            // expecting a left-click
+            if (!e.id || !builder.dbs.get("perk_cards").get(e.id).has_copycat_boost || ev.button != 0) return; 
 
-            if (!e.id || !builder.dbs.get("perk_cards").get(e.id).has_copycat_boost) return; 
-
-            switch (ev.button){
-            case 0: // left-click
-                builder.changeCardBoost(e);
-                break;
-            case 2: // right-click
-                builder.changeCardBoost(e, -1);
-                break;
-            default:
-            }
+            builder.changeCardBoost(e);
 
             const pastUnlock = builder.exp.perkDeckUnlock;
             if (pastUnlock && (builder.exp.perkDeckUnlock != pastUnlock)){
@@ -361,7 +354,35 @@ window.onload = async () => {
             }            
         });
         
-        
+        // right-click
+        e.addEventListener("contextmenu", ev => {
+            ev.preventDefault(); 
+
+            // expecting a right-click
+            if (!e.id || !builder.dbs.get("perk_cards").get(e.id).has_copycat_boost || ev.button != 2) return; 
+
+            builder.changeCardBoost(e, -1);
+
+            const pastUnlock = builder.exp.perkDeckUnlock;
+            if (pastUnlock && (builder.exp.perkDeckUnlock != pastUnlock)){
+                builder.gui.HandleUnlocks({
+                    type: "perkDeckUnlock",
+                    id: pastUnlock,
+                    unlocks: builder.dbs.get("perk_deck_unlocks").get(pastUnlock).unlocks
+                });
+            }
+
+            builder.gui.PerkCard_DisplayDescription(e); 
+
+            if(ev.isTrusted || ev.detail == -1) {
+                window.history.pushState(
+                    Util.makeState(null, builder.exp, builder.gui.Tab_Current),
+                    `used perk boost ${e.id}`,
+                    builder.io.GetEncodedBuild()
+                );
+            } 
+                       
+        });
     }
 
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -326,10 +326,20 @@ window.onload = async () => {
 
     // Perk card clickables (with boosts) //
     for(const e of document.querySelectorAll(".pk_deck_cards .pk_has_boost")) {
-        e.addEventListener("click", ev => {
+        e.addEventListener("mousedown", ev => {
+
+
             if (!e.id || !builder.dbs.get("perk_cards").get(e.id).has_copycat_boost) return; 
 
-            builder.changeCardBoost(e);
+            switch (ev.button){
+            case 0: // left-click
+                builder.changeCardBoost(e);
+                break;
+            case 2: // right-click
+                builder.changeCardBoost(e, -1);
+                break;
+            default:
+            }
 
             const pastUnlock = builder.exp.perkDeckUnlock;
             if (pastUnlock && (builder.exp.perkDeckUnlock != pastUnlock)){
@@ -349,7 +359,9 @@ window.onload = async () => {
                     builder.io.GetEncodedBuild()
                 );
             }            
-        }); 
+        });
+        
+        
     }
 
 


### PR DESCRIPTION
can now right-click to scroll backwards through copycat boosts

(needs to be mousedown event instead of click event, otherwise the context menu prevents the right-click event from actually happening on the card)